### PR TITLE
ci: add ready_for_review to pull_request types (cc#175)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
 
 jobs:


### PR DESCRIPTION
## What

Add `ready_for_review` to `pull_request:` activity types in CI workflow(s).

## Why

GitHub's default `pull_request` event activity types are `opened`, `synchronize`, `reopened`. **`ready_for_review` is NOT a default.** A workflow with bare `on: pull_request:` does NOT fire CI when a draft is marked ready via `gh pr ready` or the GitHub UI button. The PR sits with no checks until a manual close+reopen workaround.

This was discovered during CC session 678 (cc#166 fleet bump) when 4-of-4 draft PRs needed close+reopen to fire CI. Fleet-wide fix tracked in [SPTK-EPB/command-center#175](https://github.com/SPTK-EPB/command-center/issues/175).

## Change

```yaml
on:
  push:
    branches: [main]
  pull_request:
+   types: [opened, synchronize, reopened, ready_for_review]
    branches: [main]   # unchanged if present
```

## Validation

This PR's own CI is the canary — the workflow file change is exercised by the workflow itself.

## Scope

Excluded from this sweep (intentionally narrow scope, documented in cc#175):
- `cache-cleanup.yml` / `cleanup-caches.yml` (`types: [closed]` — fires on close only)
- `dependabot-auto-merge.yml` / `dependabot-lockfile.yml` (dependabot-only — bot opens ready PRs directly, never drafts)

Closes part of [SPTK-EPB/command-center#175](https://github.com/SPTK-EPB/command-center/issues/175).
